### PR TITLE
Fix build on Mono (no .GetMethod and .SetMethod on Mono 4.0 or 4.5)

### DIFF
--- a/FunJS/QuoteExtensions.fs
+++ b/FunJS/QuoteExtensions.fs
@@ -22,11 +22,11 @@ let getCaseMethodInfo (uci:UnionCaseInfo) =
       caseType.GetConstructors(flags).[0]
       :> MethodBase, caseType
    | [| :? MethodInfo as mi |] -> mi :> MethodBase, unionType
-   | [| :? PropertyInfo as pi |] -> pi.GetGetMethod() :> MethodBase, unionType
+   | [| :? PropertyInfo as pi |] -> pi.GetGetMethod(true) :> MethodBase, unionType
    | _ ->
       match unionType.GetMember("New" + uci.Name, flags) with
       | [| :? MethodInfo as mi |] -> mi :> MethodBase, unionType
-      | [| :? PropertyInfo as pi |] -> pi.GetGetMethod() :> MethodBase, unionType
+      | [| :? PropertyInfo as pi |] -> pi.GetGetMethod(true) :> MethodBase, unionType
       | _ -> failwith "never"
 
 let specialOp (mb:MethodBase) =
@@ -41,9 +41,9 @@ let tryToMethodBase = function
    | Patterns.Call(obj,mi,args) ->
       Some(obj, mi :> MethodBase, args, MethodCall)
    | Patterns.PropertyGet(obj,pi,args) -> 
-      Some(obj, pi.GetGetMethod() :> MethodBase, args, MethodCall) 
+      Some(obj, pi.GetGetMethod(true) :> MethodBase, args, MethodCall) 
    | Patterns.PropertySet(obj,pi,args,v) -> 
-      Some(obj, pi.GetSetMethod() :> MethodBase, List.append args [v], MethodCall)
+      Some(obj, pi.GetSetMethod(true) :> MethodBase, List.append args [v], MethodCall)
    | Patterns.NewUnionCase(uci, exprs) -> 
       Some(None, fst <| getCaseMethodInfo uci, exprs, UnionCaseConstructorCall)
    | Patterns.NewObject(ci, exprs) ->

--- a/FunJS/ReflectedDefinitions.fs
+++ b/FunJS/ReflectedDefinitions.fs
@@ -190,7 +190,7 @@ let private getPropertyField split (compiler:InternalCompiler.ICompiler) (pi:Pro
    compiler.DefineGlobal name (fun var ->
       // TODO: wrap in function scope?
       compiler.DefineGlobalInitialization <|
-         createCall split (ReturnStrategies.assignVar var) compiler [objExpr; exprs] (pi.GetGetMethod())
+         createCall split (ReturnStrategies.assignVar var) compiler [objExpr; exprs] (pi.GetGetMethod(true))
       []
    )
 
@@ -206,7 +206,7 @@ let private propertyGetting =
          | true, [], [] ->
             let property = getPropertyField split compiler pi objExpr exprs
             [ returnStategy.Return <| Reference property ]
-         | _ -> createCall split returnStategy compiler [objExpr; exprs] (pi.GetGetMethod())
+         | _ -> createCall split returnStategy compiler [objExpr; exprs] (pi.GetGetMethod(true))
       | _ -> []
       
 let private propertySetting =
@@ -223,7 +223,7 @@ let private propertySetting =
             [  yield! valDecl
                yield Assign(Reference property, valRef) 
             ]
-         | _ -> createCall (|Split|) returnStategy compiler [objExpr; exprs; [valExpr]] (pi.GetSetMethod())
+         | _ -> createCall (|Split|) returnStategy compiler [objExpr; exprs; [valExpr]] (pi.GetSetMethod(true))
       | _ -> []
 
 let private fieldGetting =


### PR DESCRIPTION
The library compiles just fine on Mac using 'xbuild' with F# 3.0.2 once you make this change
