### PR TITLE
Observable.pairwise fix

### DIFF
--- a/src/main/FunScript/Core/Events.fs
+++ b/src/main/FunScript/Core/Events.fs
@@ -112,7 +112,11 @@ module Observable =
                 let lastArgs = ref None
                 let newObserver =
                     ActionObserver<_>(
-                        onNext =        (fun args2 -> match !lastArgs with None->()|Some args1->observer.OnNext(args1,args2); lastArgs:=Some args2),
+                        onNext = (fun args2 ->
+                            match !lastArgs with
+                            | None -> ()
+                            | Some args1 -> observer.OnNext(args1,args2)
+                            lastArgs := Some args2),
                         onError =       (fun e -> observer.OnError(e)),
                         onCompleted =   (fun () -> observer.OnCompleted())
                     )


### PR DESCRIPTION
For some reason, the function was not working, but it did when I put the code within FunScript.Core.Events.Observable.PairwiseObservable in different lines. Maybe the quotations got messed up?
