### PR TITLE
Fixes Funscript.Typescript.Exe crash on parsing errors

### DIFF
--- a/src/extra/FunScript.TypeScript/Parser.fs
+++ b/src/extra/FunScript.TypeScript/Parser.fs
@@ -517,10 +517,14 @@ let declarationsFile : Parser<_, unit> =
     ws >>. many declarationElement .>> eof
     |>> DeclarationsFile
 
+type TypescriptParserResult = 
+    |Success of DeclarationsFile
+    |Failure of string
+
 let parseDeclarationsFile str = 
     match run declarationsFile str with
-    | Success(r,_,_) -> r
-    | Failure(msg,err,_) -> failwithf "%s" msg
+    | ParserResult.Success(r,_,_) -> Success r
+    | ParserResult.Failure(msg,err,_) -> Failure msg
 
 //let lib = System.IO.File.ReadAllText(__SOURCE_DIRECTORY__ + @"\..\Examples\Typings\lib.d.ts")
 //let lib = System.IO.File.ReadAllText(__SOURCE_DIRECTORY__ + @"\..\Examples\Typings\jquery.d.ts")


### PR DESCRIPTION
Prevents Funscript.Typescript.Exe from crashing  on parsing errors.

Logs the names of the definition files that failed to parse to console and writes detailed error messages for all parsing failures to failed-parsing.txt

Does NOT fix current parsing errors encountered when parsing [DefinitelyTyped](https://github.com/borisyankov/DefinitelyTyped) definitions
