### PR TITLE
Successfully parsing all DefinitelyTyped typescript definition files

### DIFF
--- a/src/extra/FunScript.TypeScript/TypeGenerator.fs
+++ b/src/extra/FunScript.TypeScript/TypeGenerator.fs
@@ -1160,7 +1160,7 @@ module Compiler =
                     xs |> Seq.choose (function
                         // TODO: For now we are assuming everything is exported...
                         //       ...but really we should filter and treat them differently.
-                        | Import(_, x, y) -> Some(x, y)
+                        | Import(_, x, y) when x <> y -> Some(x, y)
                         | _ -> None)
                     |> Map.ofSeq
                 let allTypeImports =


### PR DESCRIPTION
Addresses the following:
- Hex and octal escaped characters in Typescript string literals are now parsed, in addition to the Unicode escaping
- Typescript identifiers that begin with a typescript keyword (e.g. anyDB) are now correctly parsed
- Import declarations of form `import <identifier> = <entity name>` are now correctly parsed
- Compiler now ignores type imports that result in identity after calculating entity names ( for an example of when this can occur, see [insight.d.ts](https://github.com/ca-ta/DefinitelyTyped/blob/master/insight/insight.d.ts)). Not doing so results in infinite recursion when trying to resolve the types.

---

A bunch of assemblies for which compilation fails still exists. There seem to be multiple reasons and  I have yet to identify them all. 
However, one issue seems to be that there are modules and types with the same name (see, for example, `interface Data` in [vega.d.ts](https://github.com/ca-ta/DefinitelyTyped/blob/master/vega/vega.d.ts)). In my F# projects I typically use `[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]` to work around this F# limitation - I am thinking that applying the same technique to the Funscript F# file generator could work. What do you think?

I read your mentioning of re-introducing the type provider - could you point me to the source code for it? Do you see a future to the current assembly generator or are you planning to replace it? (I'm probably misunderstanding something :-) )

Thanks for Funscript!
