### PR TITLE
Fixed error when parsing identifiers that start with keywords (e.g. staticMove)

### DIFF
--- a/src/extra/FunScript.TypeScript/Parser.fs
+++ b/src/extra/FunScript.TypeScript/Parser.fs
@@ -110,10 +110,10 @@ let identifier =
     .>> ws
 
 let keyword_ws s = 
-    pstring s .>> nextCharSatisfiesNot isIdentifierChar .>> ws
+    attempt(pstring s .>> nextCharSatisfiesNot isIdentifierChar .>> ws)
 
 let keywordReturn_ws s x = 
-    stringReturn s x .>> nextCharSatisfiesNot isIdentifierChar .>> ws
+    attempt(stringReturn s x .>> nextCharSatisfiesNot isIdentifierChar .>> ws)
 
 let keywordReturn_ws1 s x = 
     attempt(stringReturn s x .>> nextCharSatisfiesNot isIdentifierChar .>> ws1)


### PR DESCRIPTION
Fixes error parsing [three-trackballcontrols.d.ts](https://github.com/borisyankov/DefinitelyTyped/blob/master/threejs/three-trackballcontrols.d.ts)
Verified that all other definition files  in [DefinitelyTyped](https://github.com/borisyankov/DefinitelyTyped) continue to be parsed correctly.