### PR TITLE
Standalone compiler improvment

### DIFF
--- a/src/FunScript.sln
+++ b/src/FunScript.sln
@@ -15,6 +15,12 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript.Rx", "extra\FunSc
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript.Compiler", "extra\FunScript.Compiler\FunScript.Compiler.fsproj", "{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CompileTestData", "CompileTestData", "{71F5249A-EDF9-4C57-B3B8-3CEE26F8A9A6}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Simple", "compileTestData\simple\Simple.fsproj", "{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "WithBindings", "compileTestData\WithBindings\WithBindings.fsproj", "{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,9 +51,21 @@ Global
 		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E8EDA6FD-20D3-4849-95DA-ED2B0AE0A869} = {71F5249A-EDF9-4C57-B3B8-3CEE26F8A9A6}
+		{5BB88A86-E7DE-43BA-B809-A0DDDAD7F21C} = {71F5249A-EDF9-4C57-B3B8-3CEE26F8A9A6}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		$0.TextStylePolicy = $2

--- a/src/FunScript.sln
+++ b/src/FunScript.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.30324.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript", "main\FunScript\FunScript.fsproj", "{E0916E67-D3B0-4C3A-AD18-4146882FCEDD}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript.Interop", "main\FunScript.Interop\FunScript.Interop.fsproj", "{1397ECEF-2A65-49CE-AFA1-B9884671BBB9}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript.Rx", "extra\FunScript.Rx\FunScript.Rx.fsproj", "{3D25CAB2-83A4-4D3B-9986-AC068FE29307}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FunScript.Compiler", "extra\FunScript.Compiler\FunScript.Compiler.fsproj", "{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{3D25CAB2-83A4-4D3B-9986-AC068FE29307}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D25CAB2-83A4-4D3B-9986-AC068FE29307}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D25CAB2-83A4-4D3B-9986-AC068FE29307}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AAD0F56-AF0F-46BD-811E-FEC88EBED669}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/compileTestData/Simple/App.config
+++ b/src/compileTestData/Simple/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/compileTestData/Simple/Program.fs
+++ b/src/compileTestData/Simple/Program.fs
@@ -1,0 +1,7 @@
+﻿[<ReflectedDefinition>]
+module Page
+
+[<FunScript.AssemblyMain>]
+let main() = 
+    let foo = "bar"
+    foo

--- a/src/compileTestData/Simple/Simple.fsproj
+++ b/src/compileTestData/Simple/Simple.fsproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>e8eda6fd-20d3-4849-95da-ed2b0ae0a869</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Simple</RootNamespace>
+    <AssemblyName>Simple</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>Simple</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\Simple.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\Simple.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\extra\FunScript.TypeScript\FunScript.TypeScript.fsproj">
+      <Name>FunScript.TypeScript</Name>
+      <Project>{164139cf-07d4-468f-b6a8-9b92504c38e4}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\main\FunScript\FunScript.fsproj">
+      <Name>FunScript</Name>
+      <Project>{e0916e67-d3b0-4c3a-ad18-4146882fcedd}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/compileTestData/WithBindings/App.config
+++ b/src/compileTestData/WithBindings/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/compileTestData/WithBindings/Program.fs
+++ b/src/compileTestData/WithBindings/Program.fs
@@ -1,0 +1,15 @@
+﻿[<ReflectedDefinition>]
+module Page
+
+open FunScript
+open FunScript.TypeScript
+
+let hello () =
+    Globals.window.alert("Hello world!")
+     
+let jq(selector : string) = Globals.Dollar.Invoke selector
+let (?) jq name = jq("#" + name)
+
+[<FunScript.AssemblyMain>]
+let main() = 
+    jq?helloWorld.click(fun _ -> hello() :> obj)

--- a/src/compileTestData/WithBindings/WithBindings.fsproj
+++ b/src/compileTestData/WithBindings/WithBindings.fsproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{5bb88a86-e7de-43ba-b809-a0dddad7f21c}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>WithBindings</RootNamespace>
+    <AssemblyName>WithBindings</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>WithBindings</Name>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\WithBindings.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\WithBindings.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FunScript.TypeScript.Binding.jquery">
+      <HintPath>..\..\packages\FunScript.TypeScript.Binding.jquery.1.1.0.37\lib\net40\FunScript.TypeScript.Binding.jquery.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FunScript.TypeScript.Binding.lib">
+      <HintPath>..\..\packages\FunScript.TypeScript.Binding.lib.1.1.0.37\lib\net40\FunScript.TypeScript.Binding.lib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\extra\FunScript.TypeScript\FunScript.TypeScript.fsproj">
+      <Name>FunScript.TypeScript</Name>
+      <Project>{164139cf-07d4-468f-b6a8-9b92504c38e4}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\main\FunScript\FunScript.fsproj">
+      <Name>FunScript</Name>
+      <Project>{e0916e67-d3b0-4c3a-ad18-4146882fcedd}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/compileTestData/WithBindings/packages.config
+++ b/src/compileTestData/WithBindings/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FunScript.TypeScript.Binding.jquery" version="1.1.0.37" targetFramework="net45" />
+  <package id="FunScript.TypeScript.Binding.lib" version="1.1.0.37" targetFramework="net45" />
+</packages>

--- a/src/extra/FunScript.Compiler/App.config
+++ b/src/extra/FunScript.Compiler/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
@@ -6,10 +6,10 @@
     <runtime>
       <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
         <dependentAssembly>
-          <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-          <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.0.0"/>
-          <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0"/>
-          <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0"/>
+          <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+          <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0" />
+          <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0" />
           
         </dependentAssembly>
       </assemblyBinding>

--- a/src/extra/FunScript.Compiler/Compile.fs
+++ b/src/extra/FunScript.Compiler/Compile.fs
@@ -1,0 +1,182 @@
+﻿module Compile
+
+    open System.Reflection
+    open System.Collections.Generic
+    open Microsoft.FSharp.Quotations
+    open Microsoft.FSharp.Compiler.SourceCodeServices
+    open Mono.Cecil
+
+    type CompileError = {Message:string}
+    type CompileResult = {
+        Success: bool
+        Errors: seq<CompileError>
+        CompiledFunScript: string
+    }
+
+    [<ReflectedDefinition>]
+    let compileMethod() = 
+        let x = true
+        x
+
+    let AssemblyToFunScript (assembly : Assembly) =
+        // Find the main method in this assembly
+        // Could offer lot more flexiblity here ...
+        let mainCompileExpr =
+            printfn "Searching for main function..."
+//            let types = Assembly.GetExecutingAssembly().GetTypes()
+//            let flags = BindingFlags.NonPublic ||| BindingFlags.Public ||| BindingFlags.Static
+//            let mains = 
+//                [ for typ in types do
+//                    for mi in typ.GetMethods(flags) do
+//                        if mi.Name = "compileMethod" then yield mi ]
+            let types = assembly.GetTypes()
+            let flags = BindingFlags.NonPublic ||| BindingFlags.Public ||| BindingFlags.Static
+            let mains = 
+                [ for typ in types do
+                    for mi in typ.GetMethods(flags) do
+                        if mi.Name = "main" then yield mi ]
+            let mainExpr = 
+                match mains with
+                | [it] -> Some(Expr.Call(it, []))
+                //| [it] -> Expr.TryGetReflectedDefinition(it)
+                | _ -> None
+            mainExpr
+
+//        let testExpr =  
+//            <@@
+//                let x = true
+//                x
+//            @@>
+
+        match mainCompileExpr with
+        | None -> 
+            {Success=false;Errors=[{Message="Could not find main function in any module."}];CompiledFunScript=""}
+        | _ ->
+            let sw = System.Diagnostics.Stopwatch.StartNew()
+            let source = FunScript.Compiler.Compiler.Compile(mainCompileExpr.Value, [])
+            printfn "Generated JavaScript in %f sec..." (float sw.ElapsedMilliseconds / 1000.0) 
+            {Success=true;Errors=Seq.empty<CompileError>;CompiledFunScript=source}
+
+    let FSharpErrorInfoPrettyMessage (error : Microsoft.FSharp.Compiler.FSharpErrorInfo) =
+        sprintf "%s %i:%i\n error: %s" error.FileName error.StartLineAlternate error.EndLineAlternate error.Message
+
+    type AssemblyRefernce = {Path:string;ReflectedAssembly:AssemblyDefinition;AssemblyName:AssemblyName}
+
+    type ExceptionOrAssembly= E of System.Exception | A of Assembly
+
+    let LoadDependencies (dependencyPaths : seq<string>) = 
+       
+        let unorderedDependencies =
+            dependencyPaths
+            |> Seq.map(fun path -> 
+                let assem = AssemblyDefinition.ReadAssembly(path)
+                {Path=path;ReflectedAssembly=assem;AssemblyName=AssemblyName(assem.FullName)}
+            )
+
+        let TopSort(roots: seq<'T>, pred: 'T -> seq<'T>, nodeIdentity: IEqualityComparer<'T>) =
+            seq {
+                let visited = HashSet(nodeIdentity)
+                let rec visit node =
+                    seq {
+                        if visited.Add(node) then
+                            for pN in pred node do
+                                yield! visit pN
+                            yield node
+                    }
+                for node in roots do
+                    yield! visit node
+            }
+
+        let comparer =
+                HashIdentity.FromFunctions<AssemblyRefernce>
+                    (fun a -> hash a.Path)
+                    (fun a b -> a.Path = b.Path)
+
+        let pred (a: AssemblyRefernce) =
+            a.ReflectedAssembly.MainModule.AssemblyReferences
+            |> Seq.choose (fun r ->
+                let n = AssemblyName(r.FullName)
+                match unorderedDependencies |> Seq.tryFind(fun x -> x.AssemblyName.FullName = n.FullName) with
+                | None -> None
+                | Some assemRef ->
+                    assemRef
+                    |> Some)
+
+        (*
+        Seperate compile domain support.
+        let handler = ResolveEventHandler(fun sender ->
+            fun eventArgs ->
+                null)
+        compileDomain.add_AssemblyResolve(handler)
+        *)
+
+        let results : seq<ExceptionOrAssembly> = 
+            TopSort(unorderedDependencies, pred, comparer)
+            |> Seq.map(fun d -> 
+                try
+                    A(Assembly.LoadFrom(d.Path))
+                with
+                | ex ->
+                    E(ex))
+        
+        results
+
+    let ProjectToFunScript (projectPath: string) =
+        let checker = FSharpChecker.Create()
+        let projectOpts = checker.GetProjectOptionsFromProjectFile(projectPath)
+
+        let dependencyPaths =
+            projectOpts.OtherOptions 
+            |> Seq.filter (fun x -> x.StartsWith("-r:"))
+            |> Seq.map (fun x -> x.Substring(3))
+
+        let dependencyResults = LoadDependencies(dependencyPaths)
+        let loadErrors =  dependencyResults |> Seq.choose(fun x ->
+            match x with
+                | A _ -> None
+                | E e -> Some e)
+        let dependencies = dependencyResults |> Seq.choose(fun x ->
+            match x with
+                | E _ -> None
+                | A a -> Some a)
+
+        match loadErrors with
+            |errors when Seq.length(errors) > 0 ->
+                let dependencyErrors = errors |> Seq.map(fun x -> {Message=x.Message})
+                {Success=false;Errors=dependencyErrors;CompiledFunScript=""}
+            |_ ->
+                let scs = Microsoft.FSharp.Compiler.SimpleSourceCodeServices.SimpleSourceCodeServices()
+                let requiredOptions = Seq.ofList [ "--validate-type-providers" ]
+
+                let baseOptions = Seq.ofArray projectOpts.OtherOptions
+
+                let options = Seq.concat [baseOptions; requiredOptions] |> Seq.distinct
+
+                let errors, exitCode, assembly = scs.CompileToDynamicAssembly(Seq.toArray options, Some(stdout, stderr))
+                let errors, exitCode = scs.Compile(Seq.toArray options)
+                
+                let handler = System.ResolveEventHandler(fun sender ->
+                    fun eventArgs ->
+                        dependencies |> Seq.find(fun x ->
+                            x.FullName = eventArgs.Name)
+                )
+
+                System.AppDomain.CurrentDomain.add_AssemblyResolve(handler)
+//                let errors = []
+//                let exitCode = 0
+                let assembly = 
+                    Assembly.LoadFrom("C:\\Projects\\FunScript.CommandLine\\FunScript.CommandLine.Example\\bin\\debug\\FunScript.CommandLine.Example.dll")
+                    |> Some
+
+                match exitCode with
+                    | i when (i < 1) ->
+                        AssemblyToFunScript(assembly.Value)
+                    | _ ->
+                        let compileErrors = 
+                            match errors with
+                                | (_) when(Seq.isEmpty errors)->
+                                    seq [{Message=sprintf "Compiler exited with code %i" exitCode}]
+                                | _ ->
+                                    seq {for err in errors 
+                                        do yield {Message=FSharpErrorInfoPrettyMessage(err)} }
+                        {Success=false;Errors=compileErrors;CompiledFunScript=""}

--- a/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
+++ b/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
@@ -26,6 +26,9 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\FunScript.Compiler.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <StartArguments>--project-path "C:\Projects\FunScript.CommandLine\FunScript.CommandLine.Example\FunScript.CommandLine.Example.fsproj" --std-out</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -56,11 +59,33 @@
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Compile Include="PowerPack\Args.fs" />
-    <Compile Include="Program.fs" />
     <None Include="App.config" />
+    <Compile Include="Compile.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Compiler.Service">
+      <HintPath>..\..\packages\FSharp.Compiler.Service.0.0.82\lib\net45\FSharp.Compiler.Service.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />

--- a/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
+++ b/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
@@ -28,7 +28,7 @@
     <Prefer32Bit>true</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-    <StartArguments>--project-path "C:\Projects\FunScript.CommandLine\FunScript.CommandLine.Example\FunScript.CommandLine.Example.fsproj" --std-out</StartArguments>
+    <StartArguments>--project-path "C:\Projects\FunScript\src\compileTestData\WithBindings\WithBindings.fsproj" --std-out</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -92,13 +92,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\main\FunScript\FunScript.fsproj">
-      <Name>FunScript</Name>
-      <Project>{e0916e67-d3b0-4c3a-ad18-4146882fcedd}</Project>
-      <Private>True</Private>
-    </ProjectReference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
+++ b/src/extra/FunScript.Compiler/FunScript.Compiler.fsproj
@@ -67,9 +67,12 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <ProjectReference Include="..\FunScript\FunScript.fsproj">
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\main\FunScript\FunScript.fsproj">
       <Name>FunScript</Name>
-      <Project>E0916E67-D3B0-4C3A-AD18-4146882FCEDD</Project>
+      <Project>{e0916e67-d3b0-4c3a-ad18-4146882fcedd}</Project>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/extra/FunScript.Compiler/Program.fs
+++ b/src/extra/FunScript.Compiler/Program.fs
@@ -1,7 +1,6 @@
 ﻿open System
 open System.IO
 open System.Reflection
-open FunScript
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Core;
 open Microsoft.FSharp.Text;
@@ -108,10 +107,11 @@ let main argv =
         ArgParser.Usage(args, usage = usageText)
         exitCode <- 1
     else 
-        let compileResult = 
+        let compileResult : Compile.CompileResult = 
             match assemPath, projectPath with 
             | (NonEmptyString, EmptyString) ->
-                Compile.AssemblyToFunScript(Reflection.Assembly.LoadFile(assemPath))
+//                Compile.AssemblyToFunScript Reflection.Assembly.LoadFile(assemPath) Reflection.Assembly.LoadFile(funScriptPath)
+                failwith "not implemented"
             | (EmptyString, NonEmptyString) ->
                 Compile.ProjectToFunScript(projectPath)
             | (_, _) ->

--- a/src/extra/FunScript.Compiler/packages.config
+++ b/src/extra/FunScript.Compiler/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Compiler.Service" version="0.0.82" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
+</packages>

--- a/src/main/FunScript/Attributes/AssemblyMain.fs
+++ b/src/main/FunScript/Attributes/AssemblyMain.fs
@@ -1,0 +1,4 @@
+﻿namespace FunScript
+
+type AssemblyMain() =
+    inherit System.Attribute()

--- a/src/main/FunScript/FunScript.fsproj
+++ b/src/main/FunScript/FunScript.fsproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\AssemblyMain.fs" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="AttributeHelpers.fs" />
     <Compile Include="ExprExtensions.fs" />

--- a/src/tests/FunScript.Tests/AssemblyCompileTests.fs
+++ b/src/tests/FunScript.Tests/AssemblyCompileTests.fs
@@ -1,0 +1,24 @@
+﻿#if INTERACTIVE
+#load "Interactive.fsx"
+open FunScript.Tests.Common
+#endif
+[<NUnit.Framework.TestFixture>] 
+module FunScript.Tests.CompileTests
+
+open System
+open System.Reflection
+open NUnit.Framework
+
+
+[<Test>]
+let ``Project compiles to js``() =
+    let compiled = FunScript.Compiler.Compiler.CompileAssembly(Assembly.Load("Simple"), false, false, true)
+    let expected = 
+        """var Page__main$;
+  Page__main$ = (function(unitVar0)
+  {
+    var foo = "bar";
+    return foo;
+  });
+  return Page__main$()"""
+    Assert.AreEqual(expected, compiled)

--- a/src/tests/FunScript.Tests/FunScript.Tests.fsproj
+++ b/src/tests/FunScript.Tests/FunScript.Tests.fsproj
@@ -83,6 +83,7 @@
     <Compile Include="EventTests.fs" />
     <Compile Include="RxTests.fs" />
     <Compile Include="GuidTests.fs" />
+    <Compile Include="AssemblyCompileTests.fs" />
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="edge\x86\node.dll">
@@ -136,6 +137,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
+    <ProjectReference Include="..\..\compileTestData\simple\Simple.fsproj">
+      <Name>Simple</Name>
+      <Project>{e8eda6fd-20d3-4849-95da-ed2b0ae0a869}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\compileTestData\WithBindings\WithBindings.fsproj">
+      <Name>WithBindings</Name>
+      <Project>{5bb88a86-e7de-43ba-b809-a0dddad7f21c}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\extra\FunScript.Compiler\FunScript.Compiler.fsproj">
+      <Name>FunScript.Compiler</Name>
+      <Project>{4aad0f56-af0f-46bd-811e-fec88ebed669}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <ProjectReference Include="..\..\extra\FunScript.Rx\FunScript.Rx.fsproj">
       <Name>FunScript.Rx</Name>
       <Project>{3d25cab2-83a4-4d3b-9986-ac068fe29307}</Project>


### PR DESCRIPTION
Refactored compilation of assemblies into FunScript core.
Added ability to compile an `fsproj` to FunScript.
Added `[<FunScript.AssemblyMain>]`attribute to tell FunScript what the main method for an assembly is.
Added ability to specify output via stdout or saving to a file.

This should pave the way for the other enhancements proposed in #153.

I had to switch `FunScript.Compiler` to call `FunScript.Compiler.Compile` via reflection due to odd issues with the jquery type provider not working.
This should be better any way, makes it where `FunScript.Compiler` is not dependent on a specific `FunScript` version.