### PR TITLE
Update project references so that Examples will compile

### DIFF
--- a/examples/Canvas/Canvas.fsproj
+++ b/examples/Canvas/Canvas.fsproj
@@ -43,10 +43,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web" />

--- a/examples/Hokusai/Hokusai.fsproj
+++ b/examples/Hokusai/Hokusai.fsproj
@@ -41,10 +41,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/Mandelbrot/Mandelbrot.fsproj
+++ b/examples/Mandelbrot/Mandelbrot.fsproj
@@ -41,10 +41,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/Mario/Mario.fsproj
+++ b/examples/Mario/Mario.fsproj
@@ -44,10 +44,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web" />

--- a/examples/MovieDatabase/MovieDatabase.fsproj
+++ b/examples/MovieDatabase/MovieDatabase.fsproj
@@ -80,13 +80,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Data">
       <HintPath>..\..\data\FunScript.Data\bin\Debug\FunScript.Data.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/Pacman/PacMan.fsproj
+++ b/examples/Pacman/PacMan.fsproj
@@ -43,10 +43,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Web" />

--- a/examples/SimpleAsync/SimpleAsync.fsproj
+++ b/examples/SimpleAsync/SimpleAsync.fsproj
@@ -67,10 +67,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/Tutorial/Tutorial.fsproj
+++ b/examples/Tutorial/Tutorial.fsproj
@@ -67,10 +67,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/Twitter/Twitter.fsproj
+++ b/examples/Twitter/Twitter.fsproj
@@ -43,10 +43,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/WorldBank/WorldBank.fsproj
+++ b/examples/WorldBank/WorldBank.fsproj
@@ -71,22 +71,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FParsec">
-      <HintPath>..\..\..\lib\FParsec.dll</HintPath>
+      <HintPath>..\..\packages\FParsec\lib\net40-client\FParsec.dll</HintPath>
     </Reference>
     <Reference Include="FParsecCS">
-      <HintPath>..\..\..\lib\FParsecCS.dll</HintPath>
+      <HintPath>..\..\packages\FParsec\lib\net40-client\FParsecCS.dll</HintPath>
     </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Data">
-      <HintPath>..\..\data\FunScript.Data\bin\Debug\FunScript.Data.dll</HintPath>
+      <HintPath>..\..\build\data\bin\FunScript.Data.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/examples/jQueryUI/jQueryUI.fsproj
+++ b/examples/jQueryUI/jQueryUI.fsproj
@@ -41,10 +41,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FunScript">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.dll</HintPath>
     </Reference>
     <Reference Include="FunScript.Interop">
-      <HintPath>..\..\main\FunScript\bin\Debug\FunScript.Interop.dll</HintPath>
+      <HintPath>..\..\build\main\bin\FunScript.Interop.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />


### PR DESCRIPTION
I noticed that the examples aren't compiling even after build.cmd executes. It looks like the build.cmd drops the binaries in /build/main and /build/data, and updating the project references to look there let me compile all the examples except for WorldBank, which has a new schema without ``School enrollment, tertiary (% gross)``, and which I didn't try to update.

Hopefully fixing the examples will make it easier for other FunScript newbies to get started.